### PR TITLE
Keep SpotBugs dependencies in a separate configuration

### DIFF
--- a/src/main/scala/nl/codestar/sbtfindsecbugs/FindSecBugs.scala
+++ b/src/main/scala/nl/codestar/sbtfindsecbugs/FindSecBugs.scala
@@ -8,8 +8,9 @@ import Keys._
 object FindSecBugs extends AutoPlugin {
   private val exitCodeOk: Int = 0
   private val exitCodeClassesMissing: Int = 2
-  
-  private val findsecbugsPluginVersion = "1.7.1"
+
+  private val spotbugsVersion = "3.1.12"
+  private val findsecbugsPluginVersion = "1.9.0"
 
   private val FindsecbugsConfig = sbt.config("findsecbugs")
   private val FindSecBugsTag = Tags.Tag("findSecBugs")
@@ -32,7 +33,7 @@ object FindSecBugs extends AutoPlugin {
     concurrentRestrictions in Global ++= (if (findSecBugsParallel.value) Nil else Seq(Tags.exclusive(FindSecBugsTag))),
     ivyConfigurations += FindsecbugsConfig,
     libraryDependencies ++= Seq(
-      "com.github.spotbugs" % "spotbugs" % "3.1.1",
+      "com.github.spotbugs" % "spotbugs" % spotbugsVersion,
       "com.h3xstream.findsecbugs" % "findsecbugs-plugin" % findsecbugsPluginVersion),
     findSecBugs := (findSecBugsTask tag FindSecBugsTag).value
   )

--- a/src/sbt-test/test-issues/test-issue-26/build.sbt
+++ b/src/sbt-test/test-issues/test-issue-26/build.sbt
@@ -1,0 +1,14 @@
+val checkDependencyLeaks = taskKey[Unit]("Check that plugin's dependencies don't leak into the project itself")
+
+// Same as in the plugin itself - we don't want to expose this yet.
+val FindsecbugsConfig = sbt.config("findsecbugs")
+
+checkDependencyLeaks := {
+  val compileCP = (Compile / dependencyClasspath).value.files.toSet
+  val spotbugsCP = (FindsecbugsConfig / dependencyClasspath).value.files.toSet
+
+  // Make sure we have the right configuration.
+  assert(spotbugsCP.size > 2)
+  // Make sure none of these libraries have leaked into the project itself.
+  assert(spotbugsCP.intersect(compileCP).isEmpty)
+}

--- a/src/sbt-test/test-issues/test-issue-26/project/build.properties
+++ b/src/sbt-test/test-issues/test-issue-26/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.0

--- a/src/sbt-test/test-issues/test-issue-26/project/plugins.sbt
+++ b/src/sbt-test/test-issues/test-issue-26/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("nl.codestar" % "sbt-findsecbugs" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/test-issues/test-issue-26/test
+++ b/src/sbt-test/test-issues/test-issue-26/test
@@ -1,0 +1,1 @@
+> checkDependencyLeaks


### PR DESCRIPTION
Closes #26.

This also includes #25 to avoid dealing with merge conflicts.