### PR TITLE
Make findSecBugs compile the project before running

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ enablePlugins(SbtPlugin)
 
 name := "sbt-findsecbugs"
 organization := "nl.codestar"
-version := "0.12"
+version := "0.13-SNAPSHOT"
 description := "The Findbugs security plugin wrapped in a sbt plugin"
 
 scalaVersion := "2.12.8"

--- a/src/sbt-test/test-output/test-error-found/test
+++ b/src/sbt-test/test-output/test-error-found/test
@@ -1,3 +1,2 @@
-> compile
 -> findSecBugs
 $ exists target/scala-2.12/findsecbugs/report.html

--- a/src/sbt-test/test-output/test-html-output/test
+++ b/src/sbt-test/test-output/test-html-output/test
@@ -1,3 +1,2 @@
-> compile
 > findSecBugs
 $ exists target/scala-2.12/findsecbugs/report.html


### PR DESCRIPTION
This makes things far more predictable when running CI, or fixing found errors locally.