### PR TITLE
Expose report output path setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ You can now run `sbt findSecBugs`.
 
 sbt-findsecbugs has one setting:
 
-|Setting|Default|Meaning|
-|---|---|---|
-|`findSecBugsExcludeFile`|`None`|Optionally provide a SpotBugs [exclusion file](https://spotbugs.readthedocs.io/en/latest/filter.html).|
-|`findSecBugsFailOnMissingClass`|`true`|Consider the 'missing class' flag as failure or not. Set this to 'false' in case you excpect and want to ignore missing class messages during the check.| 
-|`findSecBugsParallel`|`true`|In a multimodule build, whether to run the security check for all submodules in parallel. If you run into memory issues, it might help to set this to `false`.|
+| Setting                         | Default                                             | Meaning                                                                                                                                                        |
+|---------------------------------|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `findSecBugsExcludeFile`        | `None`                                              | Optionally provide a SpotBugs [exclusion file](https://spotbugs.readthedocs.io/en/latest/filter.html).                                                         |
+| `findSecBugsFailOnMissingClass` | `true`                                              | Consider the 'missing class' flag as failure or not. Set this to 'false' in case you excpect and want to ignore missing class messages during the check.       |
+| `findSecBugsParallel`           | `true`                                              | In a multimodule build, whether to run the security check for all submodules in parallel. If you run into memory issues, it might help to set this to `false`. |
+| `findSecBugs / artifactPath`    | `crossTarget.value / "findsecbugs" / "report.html"` | Output path for the resulting report.                                                                                                                          |
 
 # For developers of sbt-findsecbugs
 

--- a/src/main/scala/nl/codestar/sbtfindsecbugs/FindSecBugs.scala
+++ b/src/main/scala/nl/codestar/sbtfindsecbugs/FindSecBugs.scala
@@ -38,13 +38,14 @@ object FindSecBugs extends AutoPlugin {
       "com.h3xstream.findsecbugs" % "findsecbugs-plugin" % findsecbugsPluginVersion % FindsecbugsConfig,
       "org.slf4j" % "slf4j-simple" % "1.8.0-beta4" % FindsecbugsConfig
     ),
-    findSecBugs := (findSecBugsTask tag FindSecBugsTag).value
+    findSecBugs := (findSecBugsTask tag FindSecBugsTag).value,
+    artifactPath in findSecBugs := crossTarget.value / "findsecbugs" / "report.html"
   )
 
   private def findSecBugsTask() = Def.task {
     def commandLineClasspath(classpathFiles: Seq[File]): String = PathFinder(classpathFiles.filter(_.exists)).absString
     lazy val log = Keys.streams.value.log
-    lazy val output = crossTarget.value / "findsecbugs" / "report.html"
+    lazy val output = (artifactPath in findSecBugs).value
     lazy val classpath = commandLineClasspath((dependencyClasspath in FindsecbugsConfig).value.files)
     lazy val auxClasspath = commandLineClasspath((dependencyClasspath in Compile).value.files)
     lazy val ivyHome = ivyPaths(_.ivyHome).value.getOrElse(Path.userHome / ".ivy2")


### PR DESCRIPTION
Use case: collecting all the reports to one place in a multi-project build (e.g. to publish them as CI artifacts).