### PR TITLE
Remove hardcoded plugin JAR path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,6 @@ scriptedLaunchOpts := { scriptedLaunchOpts.value ++
 }
 scriptedBufferLog := false
 
-libraryDependencies += "com.h3xstream.findsecbugs" % "findsecbugs-plugin" % "1.9.0"
-
 bintrayRepository := "sbt-findsecbugs"
 bintrayOrganization := Some("code-star")
 

--- a/src/sbt-test/test-output/test-sbt-1.3.x/build.sbt
+++ b/src/sbt-test/test-output/test-sbt-1.3.x/build.sbt
@@ -1,0 +1,5 @@
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+    scalaVersion := "2.12.3"
+  )

--- a/src/sbt-test/test-output/test-sbt-1.3.x/project/build.properties
+++ b/src/sbt-test/test-output/test-sbt-1.3.x/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.3

--- a/src/sbt-test/test-output/test-sbt-1.3.x/project/plugins.sbt
+++ b/src/sbt-test/test-output/test-sbt-1.3.x/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("nl.codestar" % "sbt-findsecbugs" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/test-output/test-sbt-1.3.x/src/main/java/Foo.java
+++ b/src/sbt-test/test-output/test-sbt-1.3.x/src/main/java/Foo.java
@@ -1,0 +1,7 @@
+class Foo {
+  // Should trigger COMMAND_INJECTION
+  void commandInjection(String input) throws java.io.IOException {
+    Runtime r = Runtime.getRuntime();
+    r.exec("/bin/sh -c some_tool" + input);
+  }
+}

--- a/src/sbt-test/test-output/test-sbt-1.3.x/test
+++ b/src/sbt-test/test-output/test-sbt-1.3.x/test
@@ -1,0 +1,3 @@
+# We expect this to fail since we have a bug here
+-> findSecBugs
+$ exists target/scala-2.12/findsecbugs/report.html


### PR DESCRIPTION
Fixes #33.

This is a bit more flexible than currently required (the revision of the resolved plugin probably won't change), but that shouldn't be a problem.