### PR TITLE
Add findSecBugs / forkOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ sbt-findsecbugs has one setting:
 | `findSecBugsFailOnMissingClass` | `true`                                              | Consider the 'missing class' flag as failure or not. Set this to 'false' in case you excpect and want to ignore missing class messages during the check.       |
 | `findSecBugsParallel`           | `true`                                              | In a multimodule build, whether to run the security check for all submodules in parallel. If you run into memory issues, it might help to set this to `false`. |
 | `findSecBugs / artifactPath`    | `crossTarget.value / "findsecbugs" / "report.html"` | Output path for the resulting report.                                                                                                                          |
+| `findSecBugs / forkOptions`     | derived from other settings                         | Configuration for the forked JVM. Uses the corresponding settings (`findSecBugs / javaOptions`).                                                               |
 
 # For developers of sbt-findsecbugs
 


### PR DESCRIPTION
Closes #35. The setup (`outputStrategy`, `connectInput`, `javaOptions`) is a bit surprising, but this way we don't change the default behavior.