### PR TITLE
Introduce configurable priority threshold for findsecbugs tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ You can now run `sbt findSecBugs`.
 
 sbt-findsecbugs has one setting:
 
-| Setting                         | Default                                             | Meaning                                                                                                                                                        |
-|---------------------------------|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `findSecBugsExcludeFile`        | `None`                                              | Optionally provide a SpotBugs [exclusion file](https://spotbugs.readthedocs.io/en/latest/filter.html).                                                         |
-| `findSecBugsFailOnMissingClass` | `true`                                              | Consider the 'missing class' flag as failure or not. Set this to 'false' in case you excpect and want to ignore missing class messages during the check.       |
-| `findSecBugsParallel`           | `true`                                              | In a multimodule build, whether to run the security check for all submodules in parallel. If you run into memory issues, it might help to set this to `false`. |
-| `findSecBugs / artifactPath`    | `crossTarget.value / "findsecbugs" / "report.html"` | Output path for the resulting report.                                                                                                                          |
-| `findSecBugs / forkOptions`     | derived from other settings                         | Configuration for the forked JVM. Uses the corresponding settings (`findSecBugs / javaOptions`).                                                               |
+| Setting                         | Default                                             | Meaning                                                                                                                                                           |
+|---------------------------------|-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `findSecBugsExcludeFile`        | `None`                                              | Optionally provide a SpotBugs [exclusion file](https://spotbugs.readthedocs.io/en/latest/filter.html).                                                            |
+| `findSecBugsFailOnMissingClass` | `true`                                              | Consider the 'missing class' flag as failure or not. Set this to 'false' in case you excpect and want to ignore missing class messages during the check.          |
+| `findSecBugsParallel`           | `true`                                              | In a multimodule build, whether to run the security check for all submodules in parallel. If you run into memory issues, it might help to set this to `false`.    |
+| `findSecBugsPriorityThreshold`  | `Priority.Normal`                                   | Set the priority threshold. Bug instances must be at least as important as this priority to be reported. Possible values: `High`, `Normal`, `Low`, `Experimental`.|
+| `findSecBugs / artifactPath`    | `crossTarget.value / "findsecbugs" / "report.html"` | Output path for the resulting report.                                                                                                                             |
+| `findSecBugs / forkOptions`     | derived from other settings                         | Configuration for the forked JVM. Uses the corresponding settings (`findSecBugs / javaOptions`).                                                                  |
 
 # For developers of sbt-findsecbugs
 

--- a/src/main/scala/nl/codestar/sbtfindsecbugs/Priority.scala
+++ b/src/main/scala/nl/codestar/sbtfindsecbugs/Priority.scala
@@ -1,0 +1,26 @@
+package nl.codestar.sbtfindsecbugs
+
+object Priority {
+
+  sealed case class Priority(name: String)
+
+  /**
+    * Experimental priority for bug instances.
+    */
+  val Experimental = Priority("experimental")
+
+  /**
+    * Low priority for bug instances.
+    */
+  val Low = Priority("low")
+
+  /**
+    * Normal priority for bug instances.
+    */
+  val Normal = Priority("medium")
+
+  /**
+    * High priority for bug instances.
+    */
+  val High = Priority("high")
+}


### PR DESCRIPTION
Setting name: `findSecBugsPriorityThreshold`
Default value:  `Priority.Normal`   

From the original library documentation this is the description for priority threshold:
_Set the priority threshold. Bug instances must be at least as important as this priority to be reported. Possible values: `High`, `Normal`, `Low`, `Experimental`._

Example in build.sbt:
`findSecBugsPriorityThreshold := Priority.High`