### PR TITLE
Upgrade SpotBugs to 4.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "nl.codestar"
 version := "0.17-SNAPSHOT"
 description := "The Findbugs security plugin wrapped in a sbt plugin"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.13"
 scalacOptions ++= Seq("-encoding", "UTF8", "-Xfatal-warnings",
   "-deprecation", "-feature", "-unchecked", "-Xlint",
   "-Ywarn-dead-code", "-Ywarn-adapted-args"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.13

--- a/src/main/scala/nl/codestar/sbtfindsecbugs/FindSecBugs.scala
+++ b/src/main/scala/nl/codestar/sbtfindsecbugs/FindSecBugs.scala
@@ -11,8 +11,8 @@ object FindSecBugs extends AutoPlugin {
   private val exitCodeOk: Int = 0
   private val exitCodeClassesMissing: Int = 2
 
-  private val spotbugsVersion = "3.1.12"
-  private val findsecbugsPluginVersion = "1.9.0"
+  private val spotbugsVersion = "4.2.2"
+  private val findsecbugsPluginVersion = "1.11.0"
   private val pluginId = "com.h3xstream.findsecbugs" % "findsecbugs-plugin" % findsecbugsPluginVersion
 
   private val FindsecbugsConfig = sbt.config("findsecbugs")

--- a/test-project/project/build.properties
+++ b/test-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.13


### PR DESCRIPTION
Tried upgrading to sbt 1.4.9, but this resulted in errors:
```
[info] [error] Expected ID character
[info] [error] reload usage:
[info] [error]   reload   (Re)loads the current project or changes to plugins project or returns from it.
[info] [error] 
[info] [error] Expected whitespace character
[info] [error] Expected project ID
[info] [error] Expected configuration
[info] [error] Expected ':'
[info] [error] Expected key
[info] [error] Not a valid key: reload (similar: onUnload, onLoad, testLoader)
[info] [error] reload;initialize
[info] [error]       ^
[error] x test-output/test-error-found 
```
Opted to use the latest 1.3.x version instead, which works.

Tested:
1. `sbt scripted`
2. `cd test-project; sbt findSecBugs`
3. used as a local dependency for my own projects - confirmed the HTML report mentions version 4.2.2