### PR TITLE
Bloop version 2.0.13, no metals.sbt file

### DIFF
--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("nl.gn0s1s" % "sbt-dotenv" % "3.1.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.13")


### PR DESCRIPTION
#50 
- metals.sbt is not used.
- bump bloop to version 2.0.13 